### PR TITLE
Use a key inside leaflet url

### DIFF
--- a/lib/pqsdk/leaflet.rb
+++ b/lib/pqsdk/leaflet.rb
@@ -1,13 +1,13 @@
 module PQSDK
   class Leaflet
-    attr_accessor :id, :name, :url, :start_date, :end_date, :pdf_data, :image_urls
+    attr_accessor :id, :name, :url, :key, :start_date, :end_date, :pdf_data, :image_urls
 
     def initialize
       self.image_urls = []
     end
 
-    def self.find(url)
-      res = RestLayer.get('v1/leaflets', { url: url }, { 'Authorization' => "Bearer #{Token.access_token}" })
+    def self.find(url,key)
+      res = RestLayer.get('v1/leaflets', { url: url, key: key }, { 'Authorization' => "Bearer #{Token.access_token}" })
       if res[0] == 200
         Leaflet.from_json res[1]
       elsif res[0] == 404

--- a/lib/pqsdk/leaflet.rb
+++ b/lib/pqsdk/leaflet.rb
@@ -6,7 +6,7 @@ module PQSDK
       self.image_urls = []
     end
 
-    def self.find(url,key)
+    def self.find(url,key=nil)
       res = RestLayer.get('v1/leaflets', { url: url, key: key }, { 'Authorization' => "Bearer #{Token.access_token}" })
       if res[0] == 200
         Leaflet.from_json res[1]

--- a/lib/pqsdk/version.rb
+++ b/lib/pqsdk/version.rb
@@ -1,3 +1,3 @@
 module PQSDK
-  VERSION = '1.2.1'
+  VERSION = '1.2.6'
 end


### PR DESCRIPTION
When you have various leaflets and they uses a key that changes every time you take a request to website, now you can send a request to api using a string key for searcing inside the leaflet url. If that key was finded inside the leaflet's url then the api returns the leaflet
