### PR TITLE
Fix saving new store

### DIFF
--- a/lib/pqsdk/store.rb
+++ b/lib/pqsdk/store.rb
@@ -60,7 +60,7 @@ module PQSDK
         fields['phone'] = phone if phone
       end
 
-      fields['opening_hours'] = opening_hours if opening_hours.is_a?(Array) && opening_hours.try(:any?)
+      fields['opening_hours'] = opening_hours if opening_hours.is_a?(Array) && opening_hours.any?
       fields['opening_hours_text'] = opening_hours_text if opening_hours_text
 
       res = RestLayer.send(method, url, fields, { 'Authorization' => "Bearer #{Token.access_token}", 'Content-Type' => 'application/json' })

--- a/lib/pqsdk/store.rb
+++ b/lib/pqsdk/store.rb
@@ -60,8 +60,8 @@ module PQSDK
         fields['phone'] = phone if phone
       end
 
-      fields['opening_hours'] = opening_hours if opening_hours.try(:any?)
-      fields['opening_hours_text'] = opening_hours_text if opening_hours_text.present?
+      fields['opening_hours'] = opening_hours if opening_hours.is_a?(Array) && opening_hours.try(:any?)
+      fields['opening_hours_text'] = opening_hours_text if opening_hours_text
 
       res = RestLayer.send(method, url, fields, { 'Authorization' => "Bearer #{Token.access_token}", 'Content-Type' => 'application/json' })
 


### PR DESCRIPTION
There were errors, when the variables _opening_hours_ and _opening_hours_text_ are not defined.
If they are **nil**, they do not have methods such as **try** and **present?**

**try** - is available in Rails, but not in plain Ruby
**present?** - should be changed to _opening_hours_text.nil?_ or just _opening_hours_text_
